### PR TITLE
last query param can be lost

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -81,7 +81,7 @@ class Connection extends EventEmitter
         $command->setQuery($query);
 
         if (!is_callable($callback)) {
-            if ($callback != null) {
+            if ($numArgs > 1) {
                 $args[] = $callback;
             }
             $query->bindParamsFromArray($args);


### PR DESCRIPTION
fix this case:
```
$connection->query('INSERT INTO book (name, ISBN, author, created) VALUES (?, ?, ?, ?)',
    $name, $isbn, $author, 0);
```
which give:
`Fatal error: Uncaught LogicException: Params not enouth to build sql in src/Query.php:120`
