### PR TITLE
Allow for custom Connector / DNS Resolver

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -47,11 +47,15 @@ class Connection extends EventEmitter
      */
     public $parser;
 
-    public function __construct(LoopInterface $loop, array $connectOptions = array())
+    public function __construct(LoopInterface $loop, array $connectOptions = array(), Connector $connector = null)
     {
         $this->loop       = $loop;
-        $resolver         = (new \React\Dns\Resolver\Factory())->createCached('8.8.8.8', $loop);
-        $this->connector  = new Connector($loop, ['dns' => $resolver]);
+        if (!$connector) {
+            $connector    = new Connector($loop, [
+                'dns' => (new \React\Dns\Resolver\Factory())->createCached('8.8.8.8', $loop)
+            ]);
+        }
+        $this->connector  = $connector;
         $this->executor   = new Executor($this);
         $this->options    = $connectOptions + $this->options;
     }

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -47,7 +47,7 @@ class Connection extends EventEmitter
      */
     public $parser;
 
-    public function __construct(LoopInterface $loop, array $connectOptions = array(), Connector $connector = null)
+    public function __construct(LoopInterface $loop, array $connectOptions = array(), ConnectorInterface $connector = null)
     {
         $this->loop       = $loop;
         if (!$connector) {

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -5,6 +5,7 @@ namespace React\MySQL;
 use React\EventLoop\LoopInterface;
 use React\Stream\Stream;
 use React\Socket\Connector;
+use React\Socket\ConnectorInterface;
 use React\MySQL\Commands\AuthenticateCommand;
 use React\MySQL\Commands\PingCommand;
 use React\MySQL\Commands\QueryCommand;


### PR DESCRIPTION
Allow the user of the API to parse a custom Connector, so he can use it's own DNS Resolver. This is especially valid when working in a docker based environment, as docker uses it's own DNS server, so with the current solution, the names of the other docker container wont resolve