### PR TITLE
Allow to change default MySQL connection parameters in test cases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .*
 *.lock
 vendor
+phpunit.xml

--- a/tests/BaseTestCase.php
+++ b/tests/BaseTestCase.php
@@ -13,6 +13,18 @@ class BaseTestCase extends \PHPUnit_Extensions_Database_TestCase
             if (self::$pdo == null) {
                 self::$pdo = new \PDO($GLOBALS['db_dsn'], $GLOBALS['db_user'], $GLOBALS['db_passwd']);
             }
+
+            self::$pdo->query('
+                CREATE TABLE IF NOT EXISTS `book` (
+                    `id`      INT(11)      NOT NULL,
+                    `name`    VARCHAR(255) NOT NULL,
+                    `isbn`    VARCHAR(255) NOT NULL,
+                    `author`  VARCHAR(255) NOT NULL,
+                    `created` INT(11)      NOT NULL,
+                    PRIMARY KEY (`id`)
+                )
+            ');
+
             $this->conn = $this->createDefaultDBConnection(self::$pdo, ':memory:');
         }
 
@@ -22,5 +34,14 @@ class BaseTestCase extends \PHPUnit_Extensions_Database_TestCase
     protected function getDataSet()
     {
         return new \PHPUnit_Extensions_Database_DataSet_YamlDataSet(__DIR__ . '/dataset.yaml');
+    }
+
+    protected function getConnectionOptions()
+    {
+        return [
+            'dbname' => $GLOBALS['db_dbname'],
+            'user'   => $GLOBALS['db_user'],
+            'passwd' => $GLOBALS['db_passwd'],
+        ];
     }
 }

--- a/tests/ConnectionTest.php
+++ b/tests/ConnectionTest.php
@@ -4,21 +4,20 @@ namespace React\Tests\MySQL;
 
 use React\MySQL\Connection;
 
-class ConnectionTest extends \PHPUnit_Framework_TestCase
+class ConnectionTest extends BaseTestCase
 {
-    private $connectOptions = array(
-        'dbname' => 'test',
-        'user'   => 'test',
-        'passwd' => 'test'
-    );
 
     public function testConnectWithInvalidPass()
     {
+        $options = $this->getConnectionOptions();
         $loop = \React\EventLoop\Factory::create();
-        $conn = new Connection($loop, array('passwd' => 'invalidpass') + $this->connectOptions );
+        $conn = new Connection($loop, array('passwd' => 'invalidpass') + $options);
 
-        $conn->connect(function ($err, $conn) use ($loop) {
-            $this->assertEquals("Access denied for user 'test'@'localhost' (using password: YES)", $err->getMessage());
+        $conn->connect(function ($err, $conn) use ($loop, $options) {
+            $this->assertEquals(sprintf(
+                "Access denied for user '%s'@'localhost' (using password: YES)",
+                $options['user']
+            ), $err->getMessage());
             $this->assertInstanceOf('React\MySQL\Connection', $conn);
             //$loop->stop();
         });
@@ -30,7 +29,7 @@ class ConnectionTest extends \PHPUnit_Framework_TestCase
         $this->expectOutputString('endclose');
 
         $loop = \React\EventLoop\Factory::create();
-        $conn = new Connection($loop, $this->connectOptions );
+        $conn = new Connection($loop, $this->getConnectionOptions());
 
         $conn->on('end', function ($conn){
             $this->assertInstanceOf('React\MySQL\Connection', $conn);

--- a/tests/ResultQueryTest.php
+++ b/tests/ResultQueryTest.php
@@ -8,13 +8,9 @@ class ResultQueryTest extends BaseTestCase
     {
         $loop = \React\EventLoop\Factory::create();
 
-        $connection = new \React\MySQL\Connection($loop, array(
-            'dbname' => 'test',
-            'user'   => 'test',
-            'passwd' => 'test',
-        ));
-
+        $connection = new \React\MySQL\Connection($loop, $this->getConnectionOptions());
         $connection->connect(function () {});
+
         $connection->query('select * from book', function ($command, $conn) use ($loop) {
             $this->assertEquals(false, $command->hasError());
             $this->assertEquals(2, count($command->resultRows));
@@ -38,12 +34,7 @@ class ResultQueryTest extends BaseTestCase
     {
         $loop = \React\EventLoop\Factory::create();
 
-        $connection = new \React\MySQL\Connection($loop, array(
-            'dbname' => 'test',
-            'user'   => 'test',
-            'passwd' => 'test',
-        ));
-
+        $connection = new \React\MySQL\Connection($loop, $this->getConnectionOptions());
         $connection->connect(function () {});
 
         $command = $connection->query('select * from book');
@@ -69,11 +60,7 @@ class ResultQueryTest extends BaseTestCase
     {
         $loop = \React\EventLoop\Factory::create();
 
-        $connection = new \React\MySQL\Connection($loop, array(
-            'dbname' => 'test',
-            'user'   => 'test',
-            'passwd' => 'test',
-        ));
+        $connection = new \React\MySQL\Connection($loop, $this->getConnectionOptions());
 
         $callback = function () use ($connection, $loop) {
             $connection->query('select 1+1', function ($command, $conn) use ($loop) {

--- a/tests/dataset.yaml
+++ b/tests/dataset.yaml
@@ -1,7 +1,7 @@
 book:
   -
     id: 1
-    name: "Advanced PHP Progroming"
+    name: "Advanced PHP Programing"
     isbn: "aaa"
     author: "balabala"
     created: 123


### PR DESCRIPTION
For now, in all test cases, MySQL connection parameters are hardcoded so I propose to use parameters from phpunit.xml.

Also, I added 'create table' query into 'getConnection' method of 'BaseTestCase' so now we may just run phpunit without any manipulation of the database.