### PR TITLE
Documentation for Connection (and custom Connector)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,47 @@ in pure PHP, implemented the mysql protocol.
 
 See examples for usage details.
 
+## Usage
+
+### Connection
+
+The `Connection` is responsible for communicating with your MySQL server
+instance, managing the connection state and sending your database queries.
+It also registers everything with the main [`EventLoop`](https://github.com/reactphp/event-loop#usage).
+
+```php
+$loop = React\EventLoop\Factory::create();
+
+$options = array(
+    'host'   => '127.0.0.1',
+    'port'   => 3306,
+    'user'   => 'root',
+    'passwd' => '',
+    'dbname' => '',
+);
+
+$connection = new Connection($loop, $options);
+```
+
+If you need custom connector settings (DNS resolution, TLS parameters, timeouts,
+proxy servers etc.), you can explicitly pass a custom instance of the
+[`ConnectorInterface`](https://github.com/reactphp/socket#connectorinterface):
+
+```php
+$connector = new \React\Socket\Connector($loop, array(
+    'dns' => '127.0.0.1',
+    'tcp' => array(
+        'bindto' => '192.168.10.1:0'
+    ),
+    'tls' => array(
+        'verify_peer' => false,
+        'verify_peer_name' => false
+    )
+));
+
+$connection = new Connection($loop, $options, $connector);
+```
+
 ## Thanks
 
 Thanks to the following projects.

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -70,15 +70,13 @@ class Connection extends EventEmitter implements ConnectionInterface
      *
      * @param LoopInterface      $loop           ReactPHP event loop instance.
      * @param array              $connectOptions MySQL connection options.
-     * @param ConnectorInterface $connector      (optional) socket sonnector instance.
+     * @param ConnectorInterface $connector      (optional) socket connector instance.
      */
     public function __construct(LoopInterface $loop, array $connectOptions = array(), ConnectorInterface $connector = null)
     {
         $this->loop       = $loop;
         if (!$connector) {
-            $connector    = new Connector($loop, [
-                'dns' => (new \React\Dns\Resolver\Factory())->createCached('8.8.8.8', $loop)
-            ]);
+            $connector    = new Connector($loop);
         }
         $this->connector  = $connector;
         $this->executor   = new Executor($this);


### PR DESCRIPTION
This simple PR adds documentation for the `Connection` class and how an explicit instance of `ConnectorInterface` can be passed to it. This also removes the hard-coded default DNS server and makes sure this will be applied automatically once https://github.com/reactphp/socket/issues/90 is in (which I'm currently working on).